### PR TITLE
Fix Facebook webhook message type extraction

### DIFF
--- a/ai_apis/views.py
+++ b/ai_apis/views.py
@@ -301,7 +301,7 @@ class FacebookWebhook(APIView):
                     if user_info:
                         display_phone_number =value['metadata']['display_phone_number']
                         messages = value['messages'][0]['text']['body']
-                        messages_type = value['messages'][0]['text']['type']
+                        messages_type = value['messages'][0]['type']
 
                         if messages_type == "text":
                             whatsapp_status_logs = {


### PR DESCRIPTION
- Correct message type retrieval from webhook payload
- Update type extraction to use the correct nested key
- Ensure accurate message type identification for processing