### PR TITLE
Update phone number conversion logic in UniqueChatList view

### DIFF
--- a/whatsapp_apis/views.py
+++ b/whatsapp_apis/views.py
@@ -672,8 +672,15 @@ class UniqueChatList(APIView):
                     "from": "customers",
                     "let": { 
                         "phone_number": {
-                            "$toLong": {  # Changed from $toInt to $toLong
-                                "$substr": ["$_id", 2, -1]
+                            "$toDouble": {
+                                "$cond": {
+                                    "if": {"$regexMatch": {
+                                        "input": {"$substr": ["$_id", 2, -1]},
+                                        "regex": "^[0-9]+$"
+                                    }},
+                                    "then": {"$substr": ["$_id", 2, -1]},
+                                    "else": "0"  # Default value if conversion fails
+                                }
                             }
                         }
                     },


### PR DESCRIPTION
- Change conversion method from $toInt to $toDouble for phone numbers
- Implement conditional logic to handle non-numeric values, defaulting to "0" if conversion fails
- Enhance data integrity in chat list response