### PR TITLE
Update 'search' query parameter in UniqueChatList view to be optional

### DIFF
--- a/whatsapp_apis/views.py
+++ b/whatsapp_apis/views.py
@@ -623,7 +623,7 @@ class UniqueChatList(APIView):
                 openapi.IN_QUERY,
                 description="Searched text based on name",
                 type=openapi.TYPE_STRING,
-                required=True
+                required=False
             )
         ],
         responses={


### PR DESCRIPTION
- Change 'required' attribute of the 'search' query parameter from True to False
- Allow for more flexible search functionality in chat list retrieval