### PR TITLE
Add 'updated_at' field to message logs and adjust sorting in UniqueCh…

### DIFF
--- a/ai_apis/views.py
+++ b/ai_apis/views.py
@@ -313,6 +313,7 @@ class FacebookWebhook(APIView):
                                 "id": value['messages'][0]['id'],
                                 "message_status": "received",
                                 "created_at": datetime.datetime.now(),
+                                "updated_at": datetime.datetime.now(),
                                 "template_name": "template_name",
                                 "code": 0,
                                 "title": "",
@@ -347,6 +348,7 @@ class FacebookWebhook(APIView):
                     {
                         'message_status': statuses[0]['status'], 
                         f"{statuses[0]['status']}_at": int(statuses[0]['timestamp']),
+                        "updated_at": datetime.datetime.now(),
                         "code": code,
                         "title": title,
                         "error_message": message,
@@ -1158,6 +1160,7 @@ class WhatsAppMessage(APIView):
                     "id": response.json()['messages'][0]["id"],
                     "message_status": "sent",
                     "created_at": datetime.datetime.now(),
+                    "updated_at": datetime.datetime.now(),
                     "template_name": "manual"
                 }
                 db.create_document('whatsapp_message_logs', whatsapp_status_logs)
@@ -1170,6 +1173,7 @@ class WhatsAppMessage(APIView):
                     "id": "",
                     "message_status": "error",
                     "created_at": datetime.datetime.now(),
+                    "updated_at": datetime.datetime.now(),
                     "template_name": "manual",
                     "code": response.json()['error']['code'],
                     "title": response.json()['error']['type'],

--- a/utils/whatsapp_message_data.py
+++ b/utils/whatsapp_message_data.py
@@ -256,6 +256,7 @@ def send_message_data(number, template_name, text, image_url, user_id, entry=Non
                 "id": response.json()['messages'][0]["id"],
                 "message_status": response.json()['messages'][0]["message_status"] if "message_status" in response.json()['messages'][0] else "sent",
                 "created_at": datetime.datetime.now(),
+                "updated_at": datetime.datetime.now(),
                 "template_name": template_name
             }
             db.create_document('whatsapp_message_logs', whatsapp_status_logs)
@@ -268,6 +269,7 @@ def send_message_data(number, template_name, text, image_url, user_id, entry=Non
                 "id": "",
                 "message_status": "error",
                 "created_at": datetime.datetime.now(),
+                "updated_at": datetime.datetime.now(),
                 "template_name": template_name,
                 "code": response.json()['error']['code'],
                 "title": response.json()['error']['type'],

--- a/whatsapp_apis/views.py
+++ b/whatsapp_apis/views.py
@@ -711,11 +711,11 @@ class UniqueChatList(APIView):
                     **match_query,
                     **({'customer_info': {'$ne': []}} if search_text else {})
                 }},
-                {"$sort": {"created_at": -1}},
+                {"$sort": {"updated_at": -1}},
                 {"$group": {
                     "_id": "$number",
                     "last_message": {"$first": "$message"},
-                    "last_message_time": {"$first": "$created_at"},
+                    "last_message_time": {"$first": "$updated_at"},
                     "message_status": {"$first": "$message_status"},
                     "template_name": {"$first": "$template_name"},
                     "sent_at": {"$first": "$sent_at"},


### PR DESCRIPTION
…atList view

- Include 'updated_at' timestamp in WhatsApp and Facebook message logs for better tracking of message status changes
- Modify sorting in UniqueChatList view to use 'updated_at' instead of 'created_at' for more accurate retrieval of recent messages
- Ensure consistency in message log structure across different APIs