### PR TITLE
Add user_id to chart query in UserDashboard view

### DIFF
--- a/ai_apis/views.py
+++ b/ai_apis/views.py
@@ -776,6 +776,7 @@ class UserDashboard(APIView):
             
             ## we need to add the chart data
             chart_query = {
+                "user_id": user_id,
                 "sent_at": { "$gt": 0 } # Optional safeguard for sent_at
             }
             if start_date and end_date:


### PR DESCRIPTION
- Include user_id in the chart query to ensure data is filtered correctly for the specific user.
- Maintain existing functionality while enhancing the accuracy of chart data retrieval.