### PR TITLE
Update API_KEY assignment in SendMessage view for improved clarity

### DIFF
--- a/ai_apis/views.py
+++ b/ai_apis/views.py
@@ -156,6 +156,7 @@ class SendMessage(APIView):
                 API_KEY = GLAM_API_KEY
             else:
                 template_url = f"https://graph.facebook.com/v21.0/236353759566806/message_templates?name={template_name}"
+                API_KEY = API_TOKEN
             
             print(f"API_KEY: {API_KEY}")
             print(template_url)


### PR DESCRIPTION
- Assign API_KEY to API_TOKEN when constructing the template URL, ensuring consistent token usage for API interactions.
- Maintain existing functionality while enhancing clarity in the assignment of API keys.